### PR TITLE
fix: use `default` changelog for first release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
 
-  "changelog-type": "github",
+  "changelog-type": "default",
   "pull-request-title-pattern": "chore: release v${version}",
 
   "versioning": "default",


### PR DESCRIPTION
Release-As: 0.1.0