### PR TITLE
fix: disable encryption by default

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -12,8 +12,8 @@ exclude_filter="LICENSE.*,*.md"
 export_path=""
 encryption_include_filters="*"
 encryption_exclude_filters=""
-encrypt_pck=true
-encrypt_directory=true
+encrypt_pck=false
+encrypt_directory=false
 
 [preset.0.options]
 
@@ -76,8 +76,8 @@ exclude_filter="LICENSE.*,*.md"
 export_path=""
 encryption_include_filters="*"
 encryption_exclude_filters=""
-encrypt_pck=true
-encrypt_directory=true
+encrypt_pck=false
+encrypt_directory=false
 
 [preset.1.options]
 
@@ -140,8 +140,8 @@ exclude_filter="LICENSE.*,*.md"
 export_path=""
 encryption_include_filters="*"
 encryption_exclude_filters=""
-encrypt_pck=true
-encrypt_directory=true
+encrypt_pck=false
+encrypt_directory=false
 
 [preset.2.options]
 
@@ -246,8 +246,8 @@ exclude_filter="LICENSE.*,*.md"
 export_path=""
 encryption_include_filters="*"
 encryption_exclude_filters=""
-encrypt_pck=true
-encrypt_directory=true
+encrypt_pck=false
+encrypt_directory=false
 
 [preset.3.options]
 


### PR DESCRIPTION
Encryption should be enabled by instantiated projects as needed. The problem is that enabling encryption without passing a key bricks the build.